### PR TITLE
Do not keep chunks loaded forever

### DIFF
--- a/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MapUtil.java
+++ b/NCPCore/src/main/java/fr/neatmonster/nocheatplus/utilities/map/MapUtil.java
@@ -88,7 +88,7 @@ public class MapUtil {
             for (int cz = minZ; cz <= maxZ; cz ++) {
                 if (!world.isChunkLoaded(cx, cz)) {
                     try {
-                        world.loadChunk(cx, cz);
+                        world.getChunkAt(cx, cz);
                         loaded ++;
                     } catch (Exception ex) {
                         // (Can't seem to catch more precisely: TileEntity with CB 1.7.10)


### PR DESCRIPTION
The semantics of loadChunk changed in 1.14, now it would keep chunks loaded forever, so getChunkAt is the correct method.